### PR TITLE
feat(analytics): CP-3056  promo clicks data are now sent to GAEE

### DIFF
--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -2,15 +2,9 @@
     <div class="banners" data-banner-location="bottom">
         {{#each (limit banners.bottom_metadata 1)}}
             <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-promo-name="{{this.banner-name}}" data-banner-position="{{this.location}}" data-banner-name="{{this.banner-name}}">
-                {{{this.content}}}
-            </div>
-        {{/each}}
-    </div>
-
-    <div class="banners" data-banner-location="bottom">
-        {{#each (limit banners.bottom_detail_params 1)}}
-            <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-promo-name="{{this.banner-name}}" data-banner-position="{{this.location}}" data-banner-name="{{this.banner-name}}">
-                {{{this.content}}}
+                <div data-event-type="promotion-click">
+                    {{{this.content}}}
+                </div>
             </div>
         {{/each}}
     </div>

--- a/templates/components/common/header.html
+++ b/templates/components/common/header.html
@@ -2,14 +2,9 @@
     <div class="banners" data-banner-location="top">
         {{#each (limit banners.top_metadata 1)}}
             <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-promo-name="{{this.banner-name}}" data-banner-position="{{this.location}}" data-banner-name="{{this.banner-name}}">
-                {{{this.content}}}
-            </div>
-        {{/each}}
-    </div>
-    <div class="banners" data-banner-location="top">
-        {{#each (limit banners.top_detail_params 1)}}
-            <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-promo-name="{{this.banner-name}}" data-banner-position="{{this.location}}" data-banner-name="{{this.banner-name}}">
-                {{{this.content}}}
+                <div data-event-type="promotion-click">
+                    {{{this.content}}}
+                </div>
             </div>
         {{/each}}
     </div>


### PR DESCRIPTION
#### What?

To capture the Promotion click event from the storefront  and send the details to GA. 

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/CP-3056

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/39140274/41441778-f76772be-6fe8-11e8-9960-6e08c9d06062.png)


ping @bigcommerce/cp-dt
