### PR TITLE
CP-4036 Add Data tag enabled check to include data tag attributes

### DIFF
--- a/templates/components/amp/products/grid.html
+++ b/templates/components/amp/products/grid.html
@@ -1,7 +1,7 @@
 <ul class="productGrid">
     {{#each products}}
     <li class="product">
-        {{>components/amp/products/card show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer}}
+        {{>components/amp/products/card  settings=../settings show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer}}
     </li>
     {{/each}}
 </ul>

--- a/templates/components/amp/products/list-item.html
+++ b/templates/components/amp/products/list-item.html
@@ -29,7 +29,7 @@
                         {{#if out_of_stock_message }}
                         <span href="{{url}}" class="button button--primary">{{out_of_stock_message}}</span>
                         {{else}}
-                        <a href="{{add_to_cart_url}}" class="button button--primary">{{lang "products.add_to_cart"}}</a>
+                        <a href="{{add_to_cart_url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--primary">{{lang "products.add_to_cart"}}</a>
                         {{/if}}
                     {{/if}}
                 {{/unless}}

--- a/templates/components/amp/products/list.html
+++ b/templates/components/amp/products/list.html
@@ -1,7 +1,7 @@
 <ul class="productList">
     {{#each products}}
 	    <li class="product">
-	        {{>components/amp/products/list-item show_rating=../settings.show_product_rating theme_settings=../theme_settings}}
+	        {{>components/amp/products/list-item settings=../settings show_rating=../settings.show_product_rating theme_settings=../theme_settings}}
 	    </li>
     {{/each}}
 </ul>

--- a/templates/components/brand/product-listing.html
+++ b/templates/components/brand/product-listing.html
@@ -1,6 +1,6 @@
 {{> components/products/filter sort=pagination.brand.sort}}
 
-<form action="{{urls.compare}}" method='POST' data-list-name="Brand: {{brand.name}}" data-product-compare>
+<form action="{{urls.compare}}" method='POST' {{#if settings.data_tag_enabled}} data-list-name="Brand: {{brand.name}}" {{/if}} data-product-compare>
     {{#if theme_settings.product_list_display_mode '===' 'grid'}}
         {{> components/products/grid products=brand.products show_compare=brand.show_compare theme_settings=theme_settings event="list"}}
     {{else}}

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -118,7 +118,7 @@
             <ul class="productGrid">
                 {{#each cart.suggested_products}}
                     <li class="product">
-                        {{> components/products/card hide_product_quick_view=true theme_settings=../theme_settings}}
+                        {{> components/products/card settings=../settings hide_product_quick_view=true theme_settings=../theme_settings}}
                     </li>
                 {{/each}}
             </ul>

--- a/templates/components/category/product-listing.html
+++ b/templates/components/category/product-listing.html
@@ -1,10 +1,18 @@
 {{> components/products/filter sort=pagination.category.sort}}
 
-<form action="{{urls.compare}}" method='POST' data-list-name="Category: {{category.name}}" data-product-compare>
+<form action="{{urls.compare}}" method='POST' {{#if settings.data_tag_enabled}} data-list-name="Category: {{category.name}}" {{/if}} data-product-compare>
     {{#if theme_settings.product_list_display_mode '===' 'grid'}}
-        {{> components/products/grid products=category.products show_compare=category.show_compare theme_settings=theme_settings event="list"}}
+        {{#if settings.data_tag_enabled}}
+            {{> components/products/grid products=category.products show_compare=category.show_compare theme_settings=theme_settings event="list" }}
+        {{else}}
+            {{> components/products/grid products=category.products show_compare=category.show_compare theme_settings=theme_settings}}
+        {{/if}}
     {{else}}
-        {{> components/products/list products=category.products show_compare=category.show_compare theme_settings=theme_settings event="list"}}
+        {{#if settings.data_tag_enabled}}
+            {{> components/products/list products=category.products show_compare=category.show_compare theme_settings=theme_settings event="list" }}
+        {{else}}
+            {{> components/products/list products=category.products show_compare=category.show_compare theme_settings=theme_settings}}
+        {{/if}}
     {{/if}}
 </form>
 

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -1,13 +1,22 @@
 {{#if banners.bottom}}
-    <div class="banners" data-banner-location="bottom">
-        {{#each (limit banners.bottom_metadata 1)}}
-            <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-name="{{this.banner-name}}" data-position="{{this.location}}" data-name="{{this.banner-name}}">
-                <div data-event-type="promotion-click">
-                    {{{this.content}}}
+    {{#if settings.data_tag_enabled}}
+        <div class="banners" data-banner-location="bottom">
+            {{#each (limit banners.bottom_metadata 1)}}
+                <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-name="{{this.banner-name}}" data-position="{{this.location}}" data-name="{{this.banner-name}}">
+                    <div data-event-type="promotion-click">
+                        {{{this.content}}}
+                    </div>
                 </div>
+            {{/each}}
+        </div>
+    {{else}}
+        <div class="banners" data-banner-location="bottom">
+            <div class="banner">
+                {{{limit banners.bottom 1}}}
             </div>
-        {{/each}}
-    </div>
+        </div>
+    {{/if}}
+
 {{/if}}
 <footer class="footer" role="contentinfo">
     <div class="container">

--- a/templates/components/common/header.html
+++ b/templates/components/common/header.html
@@ -1,13 +1,13 @@
 {{#if banners.top}}
-    <div class="banners" data-banner-location="top">
-        {{#each (limit banners.top_metadata 1)}}
-            <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-name="{{this.banner-name}}" data-position="{{this.location}}" data-banner-id="{{this.banner-name}}">
-                <div data-event-type="promotion-click">
-                    {{{this.content}}}
-                </div>
-            </div>
-        {{/each}}
+<div class="banners" data-banner-location="top">
+    {{#each (limit banners.top_metadata 1)}}
+    <div class="banner" data-event-type="promotion" data-entity-id="{{this.id}}" data-name="{{this.banner-name}}" data-position="{{this.location}}" data-banner-id="{{this.banner-name}}">
+        <div data-event-type="promotion-click">
+            {{{this.content}}}
+        </div>
     </div>
+    {{/each}}
+</div>
 {{/if}}
 <header class="header" role="banner">
     <a href="#" class="mobileMenu-toggle" data-mobile-menu-toggle="menu">

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,4 +1,4 @@
-<article class="card {{#if alternate}}card--alternate{{/if}}" data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}">
+<article class="card {{#if alternate}}card--alternate{{/if}}" {{#if settings.data_tag_enabled}} data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"  {{/if}}>
     <figure class="card-figure">
         {{#or price.non_sale_price_with_tax price.non_sale_price_without_tax}}
             {{#if theme_settings.product_sale_badges '===' 'sash'}}
@@ -21,7 +21,7 @@
                 <img class="card-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}" title="{{image.alt}}">
             </div>
         {{else}}
-            <a href="{{url}}" data-event-type="product-click">
+            <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>
                 <div class="card-img-container">
                     <img class="card-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}" title="{{image.alt}}">
                 </div>
@@ -32,7 +32,11 @@
                 {{#unless hide_product_quick_view}}
                     {{#if theme_settings.show_product_quick_view}}
                         {{#unless demo}}
-                            <a href="#" class="button button--small card-figcaption-button quickview" data-event-type="product-click" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                            {{#if settings.data_tag_enabled}}
+                                <a href="#" class="button button--small card-figcaption-button quickview" data-event-type="product-click" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                            {{else}}
+                                <a href="#" class="button button--small card-figcaption-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                            {{/if}}
                         {{/unless}}
                     {{/if}}
                 {{/unless}}
@@ -75,7 +79,7 @@
             {{#if demo}}
                 {{name}}
             {{else}}
-                <a href="{{url}}" data-event-type="product-click">{{name}}</a>
+                <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>{{name}}</a>
             {{/if}}
         </h4>
 

--- a/templates/components/products/carousel.html
+++ b/templates/components/products/carousel.html
@@ -10,7 +10,7 @@
 >
     {{#each products}}
     <div class="productCarousel-slide">
-        {{> components/products/card theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+            {{> components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
     </div>
     {{/each}}
 </section>

--- a/templates/components/products/description.html
+++ b/templates/components/products/description.html
@@ -1,5 +1,5 @@
 <p class="productView-title">{{lang 'products.description'}}</p>
-<div class="productView-description" data-event-type="product">
+<div class="productView-description" {{#if settings.data_tag_enabled}} data-event-type="product" {{/if}}>
     {{{product.description}}}
     {{{snippet 'product_description'}}}
 </div>

--- a/templates/components/products/featured.html
+++ b/templates/components/products/featured.html
@@ -1,9 +1,9 @@
 <h2 class="page-heading">{{lang 'products.featured' }}</h2>
 
-<ul class="productGrid productGrid--maxCol{{ columns }}" data-product-type="featured" data-list-name="Featured Products">
+<ul class="productGrid productGrid--maxCol{{ columns }}" data-product-type="featured" {{#if settings.data_tag_enabled}} data-list-name="Featured Products" {{/if}}>
     {{#each products}}
         <li class="product">
-            {{>components/products/card theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+                {{>components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
         </li>
     {{/each}}
 </ul>

--- a/templates/components/products/grid.html
+++ b/templates/components/products/grid.html
@@ -1,7 +1,7 @@
 <ul class="productGrid">
     {{#each products}}
     <li class="product">
-        {{>components/products/card show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1)}}
+            {{>components/products/card settings=../settings show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1)}}
     </li>
     {{/each}}
 </ul>

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -1,10 +1,14 @@
-<article class="listItem" data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}">
+{{#if settings.data_tag_enabled}}
+    <article class="listItem" data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}">
+        {{else}}
+    <article class="listItem" >
+        {{/if}}
     <figure class="listItem-figure">
         <img class="listItem-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}" title="{{image.alt}}">
         {{#unless hide_product_quick_view}}
             {{#if theme_settings.show_product_quick_view}}
                 <div class="listItem-figureBody">
-                    <a href="#" data-event-type="product-click" class="button button--small listItem-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                    <a href="#" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--small listItem-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
                 </div>
             {{/if}}
         {{/unless}}
@@ -19,7 +23,7 @@
                 <p class="listItem-brand">{{brand.name}}</p>
                 {{/if}}
                 <h4 class="listItem-title">
-                    <a href="{{url}}" data-event-type="product-click">{{name}}</a>
+                    <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>{{name}}</a>
                 </h4>
                 {{#if summary}}
                     <p>{{{summary}}}</p>
@@ -32,13 +36,13 @@
                     {{/if}}
                     {{#if show_cart_action}}
                         {{#if has_options}}
-                            <a href="{{url}}" data-event-type="product-click" class="button button--small" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
+                            <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--small" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
                         {{/if}}
                         {{#if pre_order}}
                             <a href="{{pre_order_add_to_cart_url}}" data-event-type="product-click" class="button button--primary">{{lang 'products.pre_order'}}</a>
                         {{/if}}
                         {{#if add_to_cart_url }}
-                            <a href="{{add_to_cart_url}}" data-event-type="product-click" class="button button--primary">{{lang 'products.add_to_cart'}}</a>
+                            <a href="{{add_to_cart_url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--primary">{{lang 'products.add_to_cart'}}</a>
                         {{/if}}
                         {{#if out_of_stock_message }}
                             <a href="{{url}}" data-event-type="product-click" class="button button--small" data-product-id="{{id}}">{{out_of_stock_message}}</a>

--- a/templates/components/products/list.html
+++ b/templates/components/products/list.html
@@ -1,7 +1,11 @@
 <ul class="productList">
     {{#each products}}
     <li class="product">
-        {{>components/products/list-item show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1)}}
+        {{#if settings.data_tag_enabled}}
+            {{>components/products/list-item   show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1)}}
+        {{else}}
+            {{>components/products/list-item show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer}}
+        {{/if}}
     </li>
     {{/each}}
 </ul>

--- a/templates/components/products/new.html
+++ b/templates/components/products/new.html
@@ -1,2 +1,6 @@
 <h2 class="page-heading">{{lang 'products.new' }}</h2>
-{{> components/products/carousel products=products list="New Products"}}
+{{#if settings.data_tag_enabled}}
+    {{> components/products/carousel settings=../settings products=products list="New Products"}}
+{{else}}
+    {{> components/products/carousel products=products}}
+{{/if}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -1,5 +1,5 @@
-<div class="productView" data-event-type="product" data-entity-id="{{product.id}}" data-name="{{product.title}}" data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{product.brand.name}}" data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}">
-    {{#each product.reviews.messages}}
+<div class="productView" {{#if settings.data_tag_enabled}} data-event-type="product" data-entity-id="{{product.id}}" data-name="{{product.title}}" data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{product.brand.name}}" data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}" {{/if}}>
+{{#each product.reviews.messages}}
         {{#if error}}
             {{> components/common/alert-error error}}
         {{/if}}
@@ -245,7 +245,7 @@
         {{#if theme_settings.show_product_details_tabs}}
             {{> components/products/description-tabs}}
         {{else}}
-            {{> components/products/description}}
+            {{> components/products/description  settings=../settings}}
         {{/if}}
     </article>
 </div>

--- a/templates/components/products/quick-view.html
+++ b/templates/components/products/quick-view.html
@@ -1,3 +1,3 @@
 <div class="modal-body quickView">
-    {{> components/products/product-view schema=false}}
+    {{> components/products/product-view settings=../settings schema=false}}
 </div>

--- a/templates/components/products/related.html
+++ b/templates/components/products/related.html
@@ -1,8 +1,8 @@
 <h4>{{lang 'products.related_products' }}</h4>
-<ul class="product-list" data-list-name="Related Products">
+<ul class="product-list" {{#if settings.data_tag_enabled}} data-list-name="Related Products" {{/if}}>
     {{#each this}}
     <li class="product-card">
-        {{>components/products/card theme_settings=../theme_settings event="list" position=(add @index 1)}}
+            {{>components/products/card settings=../settings theme_settings=../theme_settings event="list" position=(add @index 1)}}
     </li>
     {{/each}}
 </ul>

--- a/templates/components/products/tabs.html
+++ b/templates/components/products/tabs.html
@@ -14,13 +14,18 @@
 <div class="tabs-contents">
 {{#if product.related_products}}
     <div role="tabpanel" aria-hidden="false" class="tab-content has-jsContent is-active" id="tab-related">
-        {{> components/products/carousel products=product.related_products columns=6 list="Related Products"}}
+        {{#if settings.data_tag_enabled}}
+            {{> components/products/carousel products=product.related_products columns=6 list="Related Products"}}
+        {{else}}
+            {{> components/products/carousel products=product.related_products columns=6}}
+        {{/if}}
     </div>
 {{/if}}
 
 {{#if product.similar_by_views}}
     <div role="tabpanel" aria-hidden="{{#if product.related_products}}true{{else}}false{{/if}}" class="tab-content has-jsContent{{#unless product.related_products}} is-active{{/unless}}" id="tab-similar">
-        {{> components/products/carousel products=product.similar_by_views columns=6 list="Customers Also Viewed"}}
+            {{> components/products/carousel settings=../settings products=product.similar_by_views columns=6 list="Customers Also Viewed"}}
+
     </div>
 {{/if}}
 </div>

--- a/templates/components/products/top.html
+++ b/templates/components/products/top.html
@@ -1,9 +1,9 @@
 <h2 class="page-heading">{{lang 'products.top' }}</h2>
 
-<ul class="productGrid productGrid--maxCol{{ columns }}" data-product-type="top_sellers" data-list-name="Most Popular Products">
-    {{#each products}}
-        <li class="product">
-            {{>components/products/card theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
-        </li>
-    {{/each}}
+<ul class="productGrid productGrid--maxCol{{ columns }}" data-product-type="top_sellers"  {{#if settings.data_tag_enabled}} data-list-name="Most Popular Products" {{/if}}>
+{{#each products}}
+<li class="product">
+    {{>components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+</li>
+{{/each}}
 </ul>

--- a/templates/components/search/product-listing.html
+++ b/templates/components/search/product-listing.html
@@ -1,11 +1,19 @@
 {{#if product_results.products.length}}
     {{> components/products/filter sort=pagination.product_results.sort}}
 {{/if}}
-<form action="{{urls.compare}}" method='POST' data-list-name="Search Results" data-product-compare>
+<form action="{{urls.compare}}" method='POST' {{#if settings.data_tag_enabled}} data-list-name="Search Results" {{/if}} data-product-compare>
     {{#if theme_settings.product_list_display_mode '===' 'grid'}}
-        {{> components/products/grid products=product_results.products show_compare=product_results.show_compare event="list" theme_settings=theme_settings}}
+        {{#if settings.data_tag_enabled}}
+            {{> components/products/grid products=product_results.products show_compare=product_results.show_compare event="list" theme_settings=theme_settings}}
+        {{else}}
+            {{> components/products/grid products=product_results.products show_compare=product_results.show_compare theme_settings=theme_settings}}
+        {{/if}}
     {{else}}
-        {{> components/products/list products=product_results.products show_compare=product_results.show_compare event="list" theme_settings=theme_settings}}
+        {{#if settings.data_tag_enabled}}
+            {{> components/products/list products=product_results.products show_compare=product_results.show_compare event="list" theme_settings=theme_settings}}
+         {{else}}
+            {{> components/products/list products=product_results.products show_compare=product_results.show_compare theme_settings=theme_settings}}
+        {{/if}}
     {{/if}}
 </form>
 

--- a/templates/components/search/quick-results.html
+++ b/templates/components/search/quick-results.html
@@ -2,11 +2,12 @@
     <a class="modal-close" aria-label="{{lang 'common.close'}}" data-drop-down-close role="button">
         <span aria-hidden="true">&#215;</span>
     </a>
-    <ul class="productGrid" data-list-name="Quick Search Results">
+    <ul class="productGrid" {{#if settings.data_tag_enabled}} data-list-name="Quick Search Results" {{/if}}>
 
         {{#each product_results.products}}
         <li class="product">
-            {{> components/products/card alternate=true show_compare=../show_compare theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+                {{> components/products/card settings=../settings alternate=true show_compare=../show_compare theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+
         </li>
         {{/each}}
     </ul>

--- a/templates/pages/amp/category.html
+++ b/templates/pages/amp/category.html
@@ -35,13 +35,13 @@ category:
     </div>
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}
-            {{> components/amp/category/product-listing}}
+            {{> components/amp/category/product-listing settings=../settings}}
         {{else}}
             <p>{{lang 'categories.no_products'}}</p>
         {{/if}}
     </main>
     {{> components/amp/category/subcategories}}
-    {{> components/amp/common/footer }}
+    {{> components/amp/common/footer settings=../settings}}
     {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
             <script type="application/json">

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -24,7 +24,7 @@ product:
 {{#partial "page"}}
     {{> components/amp/common/header }}
     <div itemscope itemtype="http://schema.org/Product">
-        {{> components/amp/products/product-view schema=true}}
+        {{> components/amp/products/product-view schema=true settings=../settings}}
     </div>
     {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
@@ -69,6 +69,6 @@ product:
             </script>
         </amp-analytics>
     {{/if}}
-    {{> components/amp/common/footer }}
+    {{> components/amp/common/footer settings=../settings}}
 {{/partial}}
 {{> layout/amp }}

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -13,7 +13,7 @@ blog:
     <h1 class="page-heading">{{ blog.name }}</h1>
 
     {{#each blog.posts}}
-        {{> components/blog/post post=this settings=../settings}}
+        {{> components/blog/post post=this  }}
     {{/each}}
 
     {{> components/common/paginator pagination.blog}}

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -29,7 +29,7 @@ brand:
 
     <main class="page-content" id="product-listing-container">
         {{#if brand.products}}
-            {{> components/brand/product-listing}}
+            {{> components/brand/product-listing settings=../settings}}
         {{else}}
             <p>{{lang 'brands.no_products'}}</p>
         {{/if}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -42,7 +42,7 @@ category:
 
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}
-            {{> components/category/product-listing}}
+            {{> components/category/product-listing settings=../settings}}
         {{else}}
             <p>{{lang 'categories.no_products'}}</p>
         {{/if}}

--- a/templates/pages/compare.html
+++ b/templates/pages/compare.html
@@ -50,15 +50,15 @@
                         {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
                             {{#if show_cart_action}}
                                 {{#if has_options}}
-                                    <a href="{{url}}" data-event-type="product-click" class="button button--primary" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
+                                    <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--primary" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
                                 {{/if}}
                                 {{#if pre_order}}
-                                    <a href="{{url}}" data-event-type="product-click" class="button button--primary" data-product-id="{{id}}">
+                                    <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--primary" data-product-id="{{id}}">
                                         {{lang 'products.pre_order'}}
                                     </a>
                                 {{/if}}
                                 {{#if add_to_cart_url}}
-                                    <a href="{{add_to_cart_url}}" data-event-type="product-click" class="button button--primary" data-product-id="{{id}}">
+                                    <a href="{{add_to_cart_url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--primary" data-product-id="{{id}}">
                                         {{lang 'products.add_to_cart'}}
                                     </a>
                                 {{/if}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -17,7 +17,7 @@ product:
     {{/each}}
 
     <div itemscope itemtype="http://schema.org/Product">
-        {{> components/products/product-view schema=true}}
+        {{> components/products/product-view settings=../settings schema=true  }}
 
         {{#if product.videos.list.length}}
             {{> components/products/videos product.videos}}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -142,7 +142,7 @@ product_results:
         {{/if}}
 
         <div id="product-listing-container" {{#if forms.search.section '!=' 'product'}}class="u-hiddenVisually"{{/if}}>
-            {{> components/search/product-listing}}
+            {{> components/search/product-listing settings=../settings}}
         </div>
     </main>
 </section>


### PR DESCRIPTION
#### What?

Include data tags only if GAEE is enabled and theme supports data tag - Relies on https://github.com/bigcommerce/bigcommerce/pull/26771/files

#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-10-26 at 3 21 39 pm" src="https://user-images.githubusercontent.com/13108529/47596079-baca0d80-d938-11e8-9ed4-e6761b4578bd.png">
<img width="1440" alt="screen shot 2018-10-26 at 3 21 44 pm" src="https://user-images.githubusercontent.com/13108529/47596080-baca0d80-d938-11e8-9945-3efa8a0acf8f.png">
![Uploading Screen Shot 2018-10-26 at 3.21.49 PM.png…]()
<img width="1440" alt="screen shot 2018-10-26 at 3 21 55 pm" src="https://user-images.githubusercontent.com/13108529/47596082-bb62a400-d938-11e8-9340-28fa666a1072.png">


@lord2800 